### PR TITLE
Bug prevalence and better docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,11 @@
 Package: anthro
 Version: 0.9.0.9000
 Title: Computation of the WHO Child Growth Standards
-Description: A package to compute the WHO Child Growth Standards. 
-             More information on the methods is available online:
+Description: Compute the WHO Child Growth Standards with calculations of
+             confidence intervals and standard errors around the
+             prevalence estimates, taking into account complex sample designs,
+             whenever is the case. More information on the methods is
+             available online:
              <http://www.who.int/childgrowth/standards/en/>.
 Authors@R: c(person("Dirk", "Schumacher", ,
                     "mail@dirk-schumacher.net", c("aut", "cre")),
@@ -10,6 +13,8 @@ Authors@R: c(person("Dirk", "Schumacher", ,
              person("Jonathan", "Polonsky", , "polonskyj@who.int", "ctb"))
 License: GPL-3
 Encoding: UTF-8
+URL: https://github.com/dirkschumacher/anthro
+BugReports: https://github.com/dirkschumacher/anthro/issues
 LazyData: true
 ByteCompile: true
 Depends: R (>= 3.2)

--- a/R/anthro.R
+++ b/R/anthro.R
@@ -1,4 +1,4 @@
-#' A package for the WHO Child Growth Standards
+#' Compute the WHO Child Growth Standards
 #'
 #' @description
 #' A package to compute the WHO Child Growth Standards.

--- a/R/prevalence.R
+++ b/R/prevalence.R
@@ -634,6 +634,7 @@ compute_prevalence_zscore_summary <-
           design,
           survey::svymean,
           na.rm = TRUE,
+          na.rm.all = TRUE,
           drop.empty.groups = FALSE
         )
       mean_est_ci_prev <-
@@ -655,19 +656,31 @@ compute_prevalence_zscore_summary <-
           design,
           survey::svymean,
           na.rm = TRUE,
+          na.rm.all = TRUE,
           drop.empty.groups = FALSE
         )
       mean_est_ci_summ <-
         confint(mean_est_summ, df = survey::degf(design))
-      mean_est_sd_summ <-
+
+      # the survey package's survey::svyvar fails if
+      # there is only one observation with an unexpected error it seems
+      # we catch this error here and set all results to NA
+      mean_est_sd_summ <- tryCatch({
         survey::svyby(
           ~ var_summ,
           ~ survey_subsets,
           design,
           survey::svyvar,
           na.rm = TRUE,
+          na.rm.all = TRUE,
           drop.empty.groups = FALSE
         )
+      }, error = function(er) {
+        data.frame(
+          dummy = rep.int(NA_real_, nrow(mean_est_ci_summ)),
+          result = rep.int(NA_real_, nrow(mean_est_ci_summ))
+        )
+      })
     })
 
     df <- data.frame(

--- a/R/prevalence.R
+++ b/R/prevalence.R
@@ -645,7 +645,8 @@ compute_prevalence_zscore_summary <-
           vartype = "ci",
           df = survey::degf(design),
           method = "logit",
-          drop.empty.groups = FALSE
+          drop.empty.groups = FALSE,
+          na.rm.all = TRUE
         )[, 3L:4L]
       mean_est_summ <-
         survey::svyby(

--- a/R/prevalence.R
+++ b/R/prevalence.R
@@ -1,5 +1,15 @@
 #' Compute prevalence estimates
 #'
+#' Prevalence estimates according to the WHO recommended standard analysis:
+#' includes prevalence estimates with corresponding standard errors
+#' and confidence intervals, and z-score summary statistics
+#' (mean and standard deviation) with most common cut-offs describing the
+#' full index distribution (-3, -2, -1, +1, +2, +3), and at disaggregated
+#' levels for all available factors (age, sex, type of residence,
+#' geographical regions, wealth quintiles, mother education and one
+#' additional factor the user is interested in and for
+#' which data are available).
+#'
 #' In this function, all available (non-missing and non-flagged) z-score values
 #' are used for each indicator-specific prevalence
 #' estimation (standard analysis).
@@ -76,7 +86,7 @@
 #'  \item{HA}{Height-for-age}
 #'  \item{WA}{Weight-for-age}
 #'  \item{WA_2}{Underweight}
-#'  \item{BMI}{Body- mass- index- for- age}
+#'  \item{BMI}{Body-mass-index-for-age}
 #'  \item{WH}{Weight-for-height}
 #'  \item{HA_WH}{Height-for-age and weight-for-height combined}
 #' }

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,8 +19,9 @@ knitr::opts_chunk$set(
 
 # Anthro
 
-The `anthro` package allows you to perform comprehensive analysis of anthropometric survey data based on the method developed by the Department of Nutrition for Health and Development at the World Health Organization.
+The `anthro` package allows you to perform comprehensive analysis of anthropometric survey data based on the [method](https://www.who.int/childgrowth/standards/en/) developed by the Department of Nutrition for Health and Development at the World Health Organization.
 
+The package is modelled after the [R macros](https://www.who.int/childgrowth/software/en/) provided by WHO. The package adds more accurate calculations of confidence intervals and standard errors around the prevalence estimates, taking into account complex sample designs, whenever is the case
 
 ## Installation
 
@@ -38,7 +39,8 @@ library(anthro)
 
 ### Z-Score
 
-This function calculates z-scores for the eight anthropometric indicators, weight-for- age, length/height-for-age, weight-for-length/height, body mass index (BMI)-for-age, head circumference-for-age, arm circumference-for-age, triceps skinfold-for-age and subscapular skinfold-for-age based on the WHO Child Growth Standards.
+This function calculates z-scores for the eight anthropometric indicators, weight-for- age, length/height-for-age, weight-for-length/height, body mass index (BMI)-for-age, head circumference-for-age, arm circumference-for-age, triceps skinfold-for-age and subscapular skinfold-for-age based on the [WHO Child Growth Standards](https://www.who.int/childgrowth/standards/en/).
+
 
 ```{r}
 anthro_zscores(sex = c(1, 2, 1, 1),
@@ -60,7 +62,7 @@ with(your_data_set,
 
 To look at all parameters, type `?anthro_zscores`.
 
-### Prevalence
+### Prevalence estimates
 
 The prevalence estimates are similiar to `anthro_zscores`: again they take vectors instead of a data frame and column names for the aforementioned reasons.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ status](https://www.r-pkg.org/badges/version/anthro)](https://cran.r-project.org
 # Anthro
 
 The `anthro` package allows you to perform comprehensive analysis of
-anthropometric survey data based on the method developed by the
+anthropometric survey data based on the
+[method](https://www.who.int/childgrowth/standards/en/) developed by the
 Department of Nutrition for Health and Development at the World Health
 Organization.
+
+The package is modelled after the [R
+macros](https://www.who.int/childgrowth/software/en/) provided by WHO.
+The package adds more accurate calculations of confidence intervals and
+standard errors around the prevalence estimates, taking into account
+complex sample designs, whenever is the case
 
 ## Installation
 
@@ -36,8 +43,8 @@ This function calculates z-scores for the eight anthropometric
 indicators, weight-for- age, length/height-for-age,
 weight-for-length/height, body mass index (BMI)-for-age, head
 circumference-for-age, arm circumference-for-age, triceps
-skinfold-for-age and subscapular skinfold-for-age based on the WHO Child
-Growth Standards.
+skinfold-for-age and subscapular skinfold-for-age based on the [WHO
+Child Growth Standards](https://www.who.int/childgrowth/standards/en/).
 
 ``` r
 anthro_zscores(sex = c(1, 2, 1, 1),
@@ -70,7 +77,7 @@ with(your_data_set,
 
 To look at all parameters, type `?anthro_zscores`.
 
-### Prevalence
+### Prevalence estimates
 
 The prevalence estimates are similiar to `anthro_zscores`: again they
 take vectors instead of a data frame and column names for the

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,8 +10,11 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
 <!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
 <script src="pkgdown.js"></script><meta property="og:title" content="Computation of the WHO Child Growth Standards">
-<meta property="og:description" content="A package to compute the WHO Child Growth Standards. 
-             More information on the methods is available online:
+<meta property="og:description" content="Compute the WHO Child Growth Standards with calculations of
+             confidence intervals and standard errors around the
+             prevalence estimates, taking into account complex sample designs,
+             whenever is the case. More information on the methods is
+             available online:
              &lt;http://www.who.int/childgrowth/standards/en/&gt;.">
 <meta name="twitter:card" content="summary">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
@@ -51,7 +54,14 @@
   <a href="news/index.html">Changelog</a>
 </li>
       </ul>
-<ul class="nav navbar-nav navbar-right"></ul>
+<ul class="nav navbar-nav navbar-right">
+<li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
+      </ul>
 </div>
 <!--/.nav-collapse -->
   </div>
@@ -70,7 +80,8 @@
 <div id="anthro" class="section level1">
 <div class="page-header"><h1 class="hasAnchor">
 <a href="#anthro" class="anchor"></a>Anthro</h1></div>
-<p>The <code>anthro</code> package allows you to perform comprehensive analysis of anthropometric survey data based on the method developed by the Department of Nutrition for Health and Development at the World Health Organization.</p>
+<p>The <code>anthro</code> package allows you to perform comprehensive analysis of anthropometric survey data based on the <a href="https://www.who.int/childgrowth/standards/en/">method</a> developed by the Department of Nutrition for Health and Development at the World Health Organization.</p>
+<p>The package is modelled after the <a href="https://www.who.int/childgrowth/software/en/">R macros</a> provided by WHO. The package adds more accurate calculations of confidence intervals and standard errors around the prevalence estimates, taking into account complex sample designs, whenever is the case</p>
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
@@ -84,7 +95,7 @@
 <div id="z-score" class="section level3">
 <h3 class="hasAnchor">
 <a href="#z-score" class="anchor"></a>Z-Score</h3>
-<p>This function calculates z-scores for the eight anthropometric indicators, weight-for- age, length/height-for-age, weight-for-length/height, body mass index (BMI)-for-age, head circumference-for-age, arm circumference-for-age, triceps skinfold-for-age and subscapular skinfold-for-age based on the WHO Child Growth Standards.</p>
+<p>This function calculates z-scores for the eight anthropometric indicators, weight-for- age, length/height-for-age, weight-for-length/height, body mass index (BMI)-for-age, head circumference-for-age, arm circumference-for-age, triceps skinfold-for-age and subscapular skinfold-for-age based on the <a href="https://www.who.int/childgrowth/standards/en/">WHO Child Growth Standards</a>.</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw"><a href="reference/anthro_zscores.html">anthro_zscores</a></span>(<span class="dt">sex =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">1</span>, <span class="dv">1</span>),</a>
 <a class="sourceLine" id="cb3-2" data-line-number="2">               <span class="dt">age =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dv">1001</span>, <span class="dv">1000</span>, <span class="dv">1010</span>, <span class="dv">1000</span>),</a>
 <a class="sourceLine" id="cb3-3" data-line-number="3">               <span class="dt">weight =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dv">18</span>, <span class="dv">15</span>, <span class="dv">10</span>, <span class="dv">15</span>),</a>
@@ -107,9 +118,9 @@
 <a class="sourceLine" id="cb4-4" data-line-number="4">                    <span class="dt">weight =</span> weight, <span class="dt">lenhei =</span> lenhei))</a></code></pre></div>
 <p>To look at all parameters, type <code><a href="reference/anthro_zscores.html">?anthro_zscores</a></code>.</p>
 </div>
-<div id="prevalence" class="section level3">
+<div id="prevalence-estimates" class="section level3">
 <h3 class="hasAnchor">
-<a href="#prevalence" class="anchor"></a>Prevalence</h3>
+<a href="#prevalence-estimates" class="anchor"></a>Prevalence estimates</h3>
 <p>The prevalence estimates are similiar to <code>anthro_zscores</code>: again they take vectors instead of a data frame and column names for the aforementioned reasons.</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1"><span class="kw"><a href="reference/anthro_prevalence.html">anthro_prevalence</a></span>(<span class="dt">sex =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">2</span>, <span class="dv">1</span>),</a>
 <a class="sourceLine" id="cb5-2" data-line-number="2">                  <span class="dt">age =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dv">1001</span>, <span class="dv">1000</span>, <span class="dv">1010</span>, <span class="dv">1000</span>),</a>
@@ -145,7 +156,16 @@
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <div class="license">
+    <div class="links">
+<h2>Links</h2>
+<ul class="list-unstyled">
+<li>Browse source code at <br><a href="https://github.com/dirkschumacher/anthro">https://​github.com/​dirkschumacher/​anthro</a>
+</li>
+<li>Report a bug at <br><a href="https://github.com/dirkschumacher/anthro/issues">https://​github.com/​dirkschumacher/​anthro/​issues</a>
+</li>
+</ul>
+</div>
+<div class="license">
 <h2>License</h2>
 <ul class="list-unstyled">
 <li><a href="LICENSE.html">Full license</a></li>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -95,7 +100,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
       <h1>Changelog <small></small></h1>
-      
+      <small>Source: <a href='https://github.com/dirkschumacher/anthro/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
     <div id="anthro-0-9-0-9000" class="section level1">

--- a/docs/reference/anthro.html
+++ b/docs/reference/anthro.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>A package for the WHO Child Growth Standards — anthro • anthro</title>
+<title>Compute the WHO Child Growth Standards — anthro • anthro</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="A package for the WHO Child Growth Standards — anthro" />
+<meta property="og:title" content="Compute the WHO Child Growth Standards — anthro" />
 
 <meta property="og:description" content="A package to compute the WHO Child Growth Standards.
 More information on the methods is available online:
@@ -86,7 +86,12 @@ More information on the methods is available online:
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,8 +104,8 @@ More information on the methods is available online:
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>A package for the WHO Child Growth Standards</h1>
-    
+    <h1>Compute the WHO Child Growth Standards</h1>
+    <small class="dont-index">Source: <a href='https://github.com/dirkschumacher/anthro/blob/master/R/anthro.R'><code>R/anthro.R</code></a></small>
     <div class="hidden name"><code>anthro.Rd</code></div>
     </div>
 

--- a/docs/reference/anthro_prevalence.html
+++ b/docs/reference/anthro_prevalence.html
@@ -32,9 +32,15 @@
 
 <meta property="og:title" content="Compute prevalence estimates — anthro_prevalence" />
 
-<meta property="og:description" content="In this function, all available (non-missing and non-flagged) z-score values
-are used for each indicator-specific prevalence
-estimation (standard analysis)." />
+<meta property="og:description" content="Prevalence estimates according to the WHO recommended standard analysis:
+includes prevalence estimates with corresponding standard errors
+and confidence intervals, and z-score summary statistics
+(mean and standard deviation) with most common cut-offs describing the
+full index distribution (-3, -2, -1, +1, +2, +3), and at disaggregated
+levels for all available factors (age, sex, type of residence,
+geographical regions, wealth quintiles, mother education and one
+additional factor the user is interested in and for
+which data are available)." />
 <meta name="twitter:card" content="summary" />
 
 
@@ -86,7 +92,12 @@ estimation (standard analysis)." />
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -100,15 +111,21 @@ estimation (standard analysis)." />
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Compute prevalence estimates</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/dirkschumacher/anthro/blob/master/R/prevalence.R'><code>R/prevalence.R</code></a></small>
     <div class="hidden name"><code>anthro_prevalence.Rd</code></div>
     </div>
 
     <div class="ref-description">
     
-    <p>In this function, all available (non-missing and non-flagged) z-score values
-are used for each indicator-specific prevalence
-estimation (standard analysis).</p>
+    <p>Prevalence estimates according to the WHO recommended standard analysis:
+includes prevalence estimates with corresponding standard errors
+and confidence intervals, and z-score summary statistics
+(mean and standard deviation) with most common cut-offs describing the
+full index distribution (-3, -2, -1, +1, +2, +3), and at disaggregated
+levels for all available factors (age, sex, type of residence,
+geographical regions, wealth quintiles, mother education and one
+additional factor the user is interested in and for
+which data are available).</p>
     
     </div>
 
@@ -302,7 +319,7 @@ data are available).</p>
  <dt>HA</dt><dd><p>Height-for-age</p></dd>
  <dt>WA</dt><dd><p>Weight-for-age</p></dd>
  <dt>WA_2</dt><dd><p>Underweight</p></dd>
- <dt>BMI</dt><dd><p>Body- mass- index- for- age</p></dd>
+ <dt>BMI</dt><dd><p>Body-mass-index-for-age</p></dd>
  <dt>WH</dt><dd><p>Weight-for-height</p></dd>
  <dt>HA_WH</dt><dd><p>Height-for-age and weight-for-height combined</p></dd>
 </dl>
@@ -344,7 +361,10 @@ data are available).</p>
     
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>Note: the function temporarily sets the <code>survey</code> option
+    <p>In this function, all available (non-missing and non-flagged) z-score values
+are used for each indicator-specific prevalence
+estimation (standard analysis).</p>
+<p>Note: the function temporarily sets the <code>survey</code> option
 <code>survey.lonely.psu</code> to "adjust" and then restores the original values.</p>
 <p>If not all parameter values have equal length, parameter values will be
 repeated to match the maximum length of all arguments except

--- a/docs/reference/anthro_zscores.html
+++ b/docs/reference/anthro_zscores.html
@@ -88,7 +88,12 @@ skinfold-for-age based on the WHO Child Growth Standards." />
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -102,7 +107,7 @@ skinfold-for-age based on the WHO Child Growth Standards." />
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Calculate z-scores for the eight anthropometric indicators</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/dirkschumacher/anthro/blob/master/R/z-score.R'><code>R/z-score.R</code></a></small>
     <div class="hidden name"><code>anthro_zscores.Rd</code></div>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/dirkschumacher/anthro">
+    <span class="fa fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -117,7 +122,7 @@
         <td>
           <p><code><a href="anthro.html">anthro</a></code> </p>
         </td>
-        <td><p>A package for the WHO Child Growth Standards</p></td>
+        <td><p>Compute the WHO Child Growth Standards</p></td>
       </tr><tr>
         
         <td>

--- a/man/anthro.Rd
+++ b/man/anthro.Rd
@@ -5,7 +5,7 @@
 \alias{anthro}
 \alias{package-anthro}
 \alias{anthro-package}
-\title{A package for the WHO Child Growth Standards}
+\title{Compute the WHO Child Growth Standards}
 \description{
 A package to compute the WHO Child Growth Standards.
 More information on the methods is available online:

--- a/man/anthro_prevalence.Rd
+++ b/man/anthro_prevalence.Rd
@@ -156,7 +156,7 @@ The resulting columns are coded with a \emph{prefix},
  \item{HA}{Height-for-age}
  \item{WA}{Weight-for-age}
  \item{WA_2}{Underweight}
- \item{BMI}{Body- mass- index- for- age}
+ \item{BMI}{Body-mass-index-for-age}
  \item{WH}{Weight-for-height}
  \item{HA_WH}{Height-for-age and weight-for-height combined}
 }
@@ -199,11 +199,21 @@ The resulting columns are coded with a \emph{prefix},
 }
 }
 \description{
+Prevalence estimates according to the WHO recommended standard analysis:
+includes prevalence estimates with corresponding standard errors
+and confidence intervals, and z-score summary statistics
+(mean and standard deviation) with most common cut-offs describing the
+full index distribution (-3, -2, -1, +1, +2, +3), and at disaggregated
+levels for all available factors (age, sex, type of residence,
+geographical regions, wealth quintiles, mother education and one
+additional factor the user is interested in and for
+which data are available).
+}
+\details{
 In this function, all available (non-missing and non-flagged) z-score values
 are used for each indicator-specific prevalence
 estimation (standard analysis).
-}
-\details{
+
 Note: the function temporarily sets the \code{survey} option
 \code{survey.lonely.psu} to "adjust" and then restores the original values.
 

--- a/tests/testthat/test-prevalence.R
+++ b/tests/testthat/test-prevalence.R
@@ -189,3 +189,14 @@ describe("anthro_prevalence()", {
     })
   })
 })
+
+test_that("bug20190222: it does not crash if all values are NA in a group", {
+  expect_silent(
+    res <- anthro_prevalence(
+      sex = c(1, 1, 1, 1, 1, 2, 2),
+      age = c(1001, 1000, 1010, 1000, 1000, 300, 300),
+      weight = c(18, 15, 10, 15, 15, 15, 15),
+      lenhei = c(100, 80, 100, 100, 100, 100, 100)
+    )
+  )
+})

--- a/tests/testthat/test-prevalence.R
+++ b/tests/testthat/test-prevalence.R
@@ -200,3 +200,14 @@ test_that("bug20190222: it does not crash if all values are NA in a group", {
     )
   )
 })
+
+test_that("bug20190222: it does not crash if too fee elements are in a group", {
+  expect_silent(
+    res <- anthro_prevalence(
+      sex = c(1, 1, 1, 1, 1, 2),
+      age = c(1001, 1000, 1010, 1000, 1000, 300),
+      weight = c(18, 15, 10, 15, 15, 15),
+      lenhei = c(100, 80, 100, 100, 100, 100)
+    )
+  )
+})


### PR DESCRIPTION
The prevalence calculation fails if one of the subsets only contains NAs. They are filtered out and the glm code fails in the survey package.