### PR TITLE
Fix typo in docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,3 @@ notifications:
 
 r_binary_packages:
   - covr
-  - survey

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - r: 3.3
     - r: 3.4
     - r: 3.5
+    - r: 3.6
       after_success:
         - Rscript -e 'covr::codecov()'
     - r: devel

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     survey
 Suggests: 
     testthat
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Collate: 
     'anthro.R'
     'assertions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # 0.9.1.9000
 
 * Removed `covr` from suggests depedencies
+* Fixed a typo in the docs
 
 # anthro 0.9.1
 

--- a/R/prevalence.R
+++ b/R/prevalence.R
@@ -64,7 +64,7 @@
 #'   sex = c(1, 2),
 #'   age = 1000, # days
 #'   weight = rnorm(100, 15, 1),
-#'   lenhei = rnorm(100, 100, 10),
+#'   lenhei = rnorm(100, 100, 10)
 #' )
 #'
 #' # Height-for-age

--- a/R/z-score.R
+++ b/R/z-score.R
@@ -127,7 +127,7 @@
 #' repeated to match the maximum length of all arguments except
 #' \code{is_age_in_month} using \code{rep_len}. This happens without warnings.
 #'
-#' Z-scores are only computed for children older than 60 months (age in months <= 60)
+#' Z-scores are only computed for children younger than 60 months (age in months <= 60)
 #'
 #' @references
 #' WHO Multicentre Growth Reference Study Group (2006). WHO Child Growth Standards: Length/height-for-age, weight-for-age, weight-for-length, weight-for-height and body mass index-for-age: Methods and development.

--- a/man/anthro_prevalence.Rd
+++ b/man/anthro_prevalence.Rd
@@ -228,7 +228,7 @@ res <- anthro_prevalence(
   sex = c(1, 2),
   age = 1000, # days
   weight = rnorm(100, 15, 1),
-  lenhei = rnorm(100, 100, 10),
+  lenhei = rnorm(100, 100, 10)
 )
 
 # Height-for-age

--- a/man/anthro_zscores.Rd
+++ b/man/anthro_zscores.Rd
@@ -139,7 +139,7 @@ If not all parameter values have equal length, parameter values will be
 repeated to match the maximum length of all arguments except
 \code{is_age_in_month} using \code{rep_len}. This happens without warnings.
 
-Z-scores are only computed for children older than 60 months (age in months <= 60)
+Z-scores are only computed for children younger than 60 months (age in months <= 60)
 }
 \description{
 This function calculates z-scores for the eight anthropometric indicators,


### PR DESCRIPTION
Z-scores are computed for children younger than 60.
Github close #15