### PR TITLE
Round age in days before adjusting lenhei

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     survey
 Suggests: 
     testthat
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Collate: 
     'anthro.R'
     'assertions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # anthro (development version)
 
+* Z-scores are now only computed for `age < 60 month` instead of `age <= 60`.
+
 # anthro 0.9.2
 
 * Age in days is now rounded half to even (e.g. 730.5 days = 731) before joining

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # anthro (development version)
 
+## Bugfix
+
 * Z-scores are now only computed for `age < 60 month` instead of `age <= 60`.
+* Z-scores for wfl were previously also computed when `age >= 60` months and `<= 1856 days`.
 
 # anthro 0.9.2
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,11 @@ age_to_days <- function(age, is_age_in_month) {
   }
 }
 
+age_under_60_month <- function(age_in_days) {
+  age_in_months <- age_to_months(age_in_days, is_age_in_month = FALSE)
+  age_in_months < 60
+}
+
 #' banker's rounding for 0 digits and positive numerics
 #' i.e. < .5 down, >= .5 up
 #' @noRd

--- a/R/z-score-helper.R
+++ b/R/z-score-helper.R
@@ -93,6 +93,7 @@ flag_zscore <- function(flag_threshold, score_name, zscore, valid_zscore) {
 #' @noRd
 adjust_lenhei <- function(age_in_days, measure, lenhei) {
   stopifnot(is.character(measure), is.numeric(age_in_days), is.numeric(lenhei))
+  age_in_days <- round_up(age_in_days)
   lenhei <-
     ifelse(
       !is.na(age_in_days) &

--- a/R/z-score-helper.R
+++ b/R/z-score-helper.R
@@ -143,9 +143,10 @@ anthro_zscore_adjusted <-
       age_in_days, sex, measure
     )
 
-    # we only compute zscores for children age <= 60 months
+    # we only compute zscores for children age < 60 months
+    # the age in months is unrouned
     age_in_months <- age_to_months(age_in_days, is_age_in_month = FALSE)
-    valid_age <- age_in_months <= 60
+    valid_age <- age_in_months < 60
 
     # at last we set certain zscores to NA
     valid_zscore <- !is.na(age_in_days) &

--- a/R/z-score-helper.R
+++ b/R/z-score-helper.R
@@ -145,8 +145,7 @@ anthro_zscore_adjusted <-
 
     # we only compute zscores for children age < 60 months
     # the age in months is unrouned
-    age_in_months <- age_to_months(age_in_days, is_age_in_month = FALSE)
-    valid_age <- age_in_months < 60
+    valid_age <- age_under_60_month(age_in_days)
 
     # at last we set certain zscores to NA
     valid_zscore <- !is.na(age_in_days) &

--- a/R/z-score-weight-for-lenhei.R
+++ b/R/z-score-weight-for-lenhei.R
@@ -118,6 +118,7 @@ anthro_zscore_weight_for_lenhei <-
 
     valid_zscore <- valid_zscore & !(oedema %in% "y")
     valid_zscore <- valid_zscore & (is.na(age_in_days) | (age_in_days <= 1856))
+    valid_zscore <- valid_zscore & age_under_60_month(age_in_days)
 
     flag_zscore(flag_threshold, "wfl", zscore, valid_zscore)
   }

--- a/R/z-score.R
+++ b/R/z-score.R
@@ -127,7 +127,7 @@
 #' repeated to match the maximum length of all arguments except
 #' \code{is_age_in_month} using \code{rep_len}. This happens without warnings.
 #'
-#' Z-scores are only computed for children younger than 60 months (age in months <= 60)
+#' Z-scores are only computed for children younger than 60 months (age in months < 60)
 #'
 #' @references
 #' WHO Multicentre Growth Reference Study Group (2006). WHO Child Growth Standards: Length/height-for-age, weight-for-age, weight-for-length, weight-for-height and body mass index-for-age: Methods and development.

--- a/man/anthro_zscores.Rd
+++ b/man/anthro_zscores.Rd
@@ -148,7 +148,7 @@ If not all parameter values have equal length, parameter values will be
 repeated to match the maximum length of all arguments except
 \code{is_age_in_month} using \code{rep_len}. This happens without warnings.
 
-Z-scores are only computed for children younger than 60 months (age in months <= 60)
+Z-scores are only computed for children younger than 60 months (age in months < 60)
 }
 \description{
 This function calculates z-scores for the eight anthropometric indicators,

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -25,3 +25,7 @@ test_that("rounding up works", {
   expect_error(round_up("730"))
   expect_error(round_up(-1))
 })
+
+test_that("adjusting lenhei uses rounded age in days", {
+  expect_equal(77.5, adjust_lenhei(730.5, "h", 77.5))
+})

--- a/tests/testthat/test-zscore-weight-for-lenhei.R
+++ b/tests/testthat/test-zscore-weight-for-lenhei.R
@@ -27,3 +27,15 @@ test_that("it returns NA if lenhei is <= 0", {
   expect_true(all(is.na(observed$fwfl)))
   expect_true(is.numeric(observed$zwfl))
 })
+
+test_that("it is only computed if age in month < 60", {
+  observed <- anthro_zscore_weight_for_lenhei(
+    weight = c(20, 20),
+    lenhei = c(80, 80),
+    lenhei_unit = c("l", "l"),
+    age_in_days = c(age_to_days(60, TRUE), age_to_days(60, TRUE) - 0.01),
+    sex = c(2, 2),
+    oedema = c("n", "n")
+  )
+  expect_equal(is.na(observed$zwfl), c(TRUE, FALSE))
+})

--- a/tests/testthat/test-zscores.R
+++ b/tests/testthat/test-zscores.R
@@ -223,3 +223,16 @@ test_that("cleaned sex variable is part of the output data.frame", {
   )
   expect_equal(res$csex, c(1L, 2L, 1L, 2L, NA_integer_))
 })
+
+test_that("clenhei takes the measure argument into account correctly", {
+  res <- anthro_zscores(
+    sex = 2,
+    age = 24,
+    lenhei = 77.5,
+    weight = 8.8,
+    is_age_in_month = TRUE,
+    measure = c("h", NA_character_)
+  )
+  expect_equal(res$clenhei, c(77.5, 77.5))
+  expect_equal(res$zlen, c(-2.55, -2.55))
+})

--- a/tests/testthat/test-zscores.R
+++ b/tests/testthat/test-zscores.R
@@ -190,16 +190,17 @@ test_that("young children with measured standing will not be adjusted", {
   expect_equal(res$cmeasure, c(NA_character_, "h"))
 })
 
-test_that("zcores are only computed for children younger or equal to 60 months", {
+test_that("zcores are only computed for children younger to 60 months", {
   res <- anthro_zscores(
     sex = 1,
-    age = c(60, 60.1),
+    age = c(59.9, 60, 60.1),
     is_age_in_month = TRUE,
     lenhei = 60,
     weight = 60,
     measure = "h"
   )
-  expect_true(all(is.na(res[2, -1:-4])))
+  expect_true(all(is.na(res[2:3, -1:-4])))
+  expect_false(all(is.na(res[1, -1:-4])))
 })
 
 test_that("height measurements are used for age 24 months", {

--- a/tests/testthat/test-zscores.R
+++ b/tests/testthat/test-zscores.R
@@ -195,8 +195,12 @@ test_that("zcores are only computed for children younger to 60 months", {
     sex = 1,
     age = c(59.9, 60, 60.1),
     is_age_in_month = TRUE,
-    lenhei = 60,
-    weight = 60,
+    lenhei = 80,
+    weight = 20,
+    armc = 5,
+    triskin = 3,
+    subskin = 5,
+    headc = 5,
     measure = "h"
   )
   expect_true(all(is.na(res[2:3, -1:-4])))


### PR DESCRIPTION
This improves consistency with previous implementations. If age is given in months it is converted to days and then compared to a threshold. This comparison was previously done using full precision but now happens on the rounded values to cover certain edge cases.