### PR TITLE
Improve handing of age

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # anthro (development version)
 
+## General
+
+* Handling of age information is improved and loss of information from
+  converting from age in days to age in months or vice verse is reduced.
+* Some code improvements.
+
+## Bugfix
+
+* Fixed a bug where, observations where erroneously removed from prevalence
+  computation. This happens if age in months was supplied, then values
+  `> 59.992` months were considered `> 1826` days. Now anything above
+  `60.009` months is considered `> 1826` days and thus excluded.
+
 # anthro 0.9.3
 
 ## General

--- a/R/prevalence.R
+++ b/R/prevalence.R
@@ -56,7 +56,8 @@
 #' for stratified analysis.
 #'
 #' @examples
-#' \dontrun{ # because it takes too long for CRAN checks
+#' \dontrun{
+#' # because it takes too long for CRAN checks
 #' library(anthro)
 #'
 #' # compute the prevalence estimates for 100 random children
@@ -234,7 +235,7 @@ anthro_prevalence <- function(sex,
   stopifnot(nrow(zscores) == length(sex))
 
   age_in_days <- age_to_days(age, is_age_in_month = is_age_in_month)
-  age_in_months <- age_in_days / ANTHRO_DAYS_OF_MONTH
+  age_in_months <- age_to_months(age, is_age_in_month = is_age_in_month)
 
   oedema <- standardize_oedema_var(oedema)
 
@@ -647,7 +648,7 @@ compute_prevalence_zscore_summary <- function(survey_data) {
   suppressWarnings({
     vecn_prev <-
       survey::svyby(
-        ~I(!is.na(var_prev)),
+        ~ I(!is.na(var_prev)),
         ~survey_subsets,
         design,
         survey::svytotal,
@@ -655,7 +656,7 @@ compute_prevalence_zscore_summary <- function(survey_data) {
       )
     vecn_unw_prev <-
       survey::svyby(
-        ~I(!is.na(var_prev)),
+        ~ I(!is.na(var_prev)),
         ~survey_subsets,
         design_unweighted,
         survey::svytotal,
@@ -699,22 +700,25 @@ compute_prevalence_zscore_summary <- function(survey_data) {
     # the survey package's survey::svyvar fails if
     # there is only one observation with an unexpected error it seems
     # we catch this error here and set all results to NA
-    mean_est_sd_summ <- tryCatch({
-      survey::svyby(
-        ~var_summ,
-        ~survey_subsets,
-        design,
-        survey::svyvar,
-        na.rm = TRUE,
-        na.rm.all = TRUE,
-        drop.empty.groups = FALSE
-      )
-    }, error = function(er) {
-      data.frame(
-        dummy = rep.int(NA_real_, nrow(mean_est_ci_summ)),
-        result = rep.int(NA_real_, nrow(mean_est_ci_summ))
-      )
-    })
+    mean_est_sd_summ <- tryCatch(
+      {
+        survey::svyby(
+          ~var_summ,
+          ~survey_subsets,
+          design,
+          survey::svyvar,
+          na.rm = TRUE,
+          na.rm.all = TRUE,
+          drop.empty.groups = FALSE
+        )
+      },
+      error = function(er) {
+        data.frame(
+          dummy = rep.int(NA_real_, nrow(mean_est_ci_summ)),
+          result = rep.int(NA_real_, nrow(mean_est_ci_summ))
+        )
+      }
+    )
   })
 
   df <- data.frame(

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,16 +18,13 @@ standardize_oedema_var <- function(oedema) {
 }
 
 age_to_days <- function(age, is_age_in_month) {
-  if (is_age_in_month) {
+  # age in days is always treated as rounded integers
+  res <- if (is_age_in_month) {
     age * ANTHRO_DAYS_OF_MONTH
   } else {
     age
   }
-}
-
-age_under_60_month <- function(age_in_days) {
-  age_in_months <- age_to_months(age_in_days, is_age_in_month = FALSE)
-  age_in_months < 60
+  as.integer(round_up(res))
 }
 
 #' banker's rounding for 0 digits and positive numerics

--- a/R/z-score-arm-circumference-for-age.R
+++ b/R/z-score-arm-circumference-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param armc numeric
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,10 +11,16 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_arm_circumference_for_age <-
-  function(armc, age_in_days, sex, flag_threshold = 5,
-             growthstandards = growthstandards_acanthro) {
-    anthro_zscore_adjusted("ac", armc, age_in_days, sex,
-      growthstandards, flag_threshold,
+  function(armc, age_in_days, age_in_months, sex, flag_threshold = 5,
+           growthstandards = growthstandards_acanthro) {
+    anthro_zscore_adjusted(
+      name = "ac",
+      measure = armc,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = sex,
+      growthstandards = growthstandards,
+      flag_threshold = flag_threshold,
       allowed_age_range = c(91, 1856)
     )
   }

--- a/R/z-score-bmi-for-age.R
+++ b/R/z-score-bmi-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param bmi numeric
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,10 +11,16 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_bmi_for_age <-
-  function(bmi, age_in_days, sex, oedema, flag_threshold = 5,
-             growthstandards = growthstandards_bmianthro) {
-    anthro_zscore_adjusted("bmi", bmi, age_in_days, sex,
-      growthstandards, flag_threshold,
+  function(bmi, age_in_days, age_in_months, sex, oedema, flag_threshold = 5,
+           growthstandards = growthstandards_bmianthro) {
+    anthro_zscore_adjusted(
+      name = "bmi",
+      measure = bmi,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = sex,
+      growthstandards = growthstandards,
+      flag_threshold = flag_threshold,
       allowed_age_range = c(0, 1856), !(oedema %in% "y")
     )
   }

--- a/R/z-score-head-circumference-for-age.R
+++ b/R/z-score-head-circumference-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param headc numeric,
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,10 +11,16 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_head_circumference_for_age <-
-  function(headc, age_in_days, sex, flag_threshold = 5,
-             growthstandards = growthstandards_hcanthro) {
-    anthro_zscore_adjusted("hc", headc, age_in_days, sex,
-      growthstandards, flag_threshold,
+  function(headc, age_in_days, age_in_months, sex, flag_threshold = 5,
+           growthstandards = growthstandards_hcanthro) {
+    anthro_zscore_adjusted(
+      name = "hc",
+      measure = headc,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = sex,
+      growthstandards = growthstandards,
+      flag_threshold = flag_threshold,
       allowed_age_range = c(0, 1856),
       zscore_fun = compute_zscore
     )

--- a/R/z-score-helper.R
+++ b/R/z-score-helper.R
@@ -113,16 +113,17 @@ adjust_lenhei <- function(age_in_days, measure, lenhei) {
 }
 
 anthro_zscore_adjusted <-
-  function(name, measure, age_in_days, sex, growthstandards, flag_threshold,
-             allowed_age_range = c(0, 1856),
-             zscore_is_valid = rep.int(TRUE, length(measure)),
-             zscore_fun = compute_zscore_adjusted) {
+  function(name, measure, age_in_days, age_in_months, sex, growthstandards, flag_threshold,
+           allowed_age_range = c(0, 1856),
+           zscore_is_valid = rep.int(TRUE, length(measure)),
+           zscore_fun = compute_zscore_adjusted) {
     stopifnot(is.character(name), length(name) == 1L, !is.na(name))
     stopifnot(is.numeric(measure))
     stopifnot(
       is.numeric(allowed_age_range), length(allowed_age_range) == 2L,
       !any(is.na(allowed_age_range))
     )
+    stopifnot(is.numeric(age_in_months))
     stopifnot(
       is.logical(zscore_is_valid),
       length(zscore_is_valid) == length(measure)
@@ -145,7 +146,7 @@ anthro_zscore_adjusted <-
 
     # we only compute zscores for children age < 60 months
     # the age in months is unrouned
-    valid_age <- age_under_60_month(age_in_days)
+    valid_age <- age_in_months < 60
 
     # at last we set certain zscores to NA
     valid_zscore <- !is.na(age_in_days) &

--- a/R/z-score-length-for-age.R
+++ b/R/z-score-length-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param lenhei numeric, the standardized length/height measure in cm. No further modification is done
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,10 +11,16 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_length_for_age <-
-  function(lenhei, age_in_days, sex, flag_threshold = 6,
-             growthstandards = growthstandards_lenanthro) {
-    anthro_zscore_adjusted("len", lenhei, age_in_days, sex,
-      growthstandards, flag_threshold,
+  function(lenhei, age_in_days, age_in_months, sex, flag_threshold = 6,
+           growthstandards = growthstandards_lenanthro) {
+    anthro_zscore_adjusted(
+      name = "len",
+      measure = lenhei,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = sex,
+      growthstandards = growthstandards,
+      flag_threshold = flag_threshold,
       allowed_age_range = c(0, 1856),
       zscore_fun = compute_zscore
     )

--- a/R/z-score-subscapular-skinfold-for-age.R
+++ b/R/z-score-subscapular-skinfold-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param subskin numeric
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,10 +11,16 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_subscapular_skinfold_for_age <-
-  function(subskin, age_in_days, sex, flag_threshold = 5,
-             growthstandards = growthstandards_ssanthro) {
-    anthro_zscore_adjusted("ss", subskin, age_in_days, sex,
-      growthstandards, flag_threshold,
+  function(subskin, age_in_days, age_in_months, sex, flag_threshold = 5,
+           growthstandards = growthstandards_ssanthro) {
+    anthro_zscore_adjusted(
+      name = "ss",
+      measure = subskin,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = sex,
+      growthstandards = growthstandards,
+      flag_threshold = flag_threshold,
       allowed_age_range = c(91, 1856)
     )
   }

--- a/R/z-score-triceps-skinfold-for-age.R
+++ b/R/z-score-triceps-skinfold-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param triskin numeric
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,10 +11,16 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_triceps_skinfold_for_age <-
-  function(triskin, age_in_days, sex, flag_threshold = 5,
-             growthstandards = growthstandards_tsanthro) {
-    anthro_zscore_adjusted("ts", triskin, age_in_days, sex,
-      growthstandards, flag_threshold,
+  function(triskin, age_in_days, age_in_months, sex, flag_threshold = 5,
+           growthstandards = growthstandards_tsanthro) {
+    anthro_zscore_adjusted(
+      name = "ts",
+      measure = triskin,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = sex,
+      growthstandards = growthstandards,
+      flag_threshold = flag_threshold,
       allowed_age_range = c(91, 1856)
     )
   }

--- a/R/z-score-weight-for-age.R
+++ b/R/z-score-weight-for-age.R
@@ -2,6 +2,7 @@
 #'
 #' @param weight numeric
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold. If the absolute value of the z-score is greater than
 #'        this parameter, the z-score gets flagged in the resulting data frame.
@@ -10,9 +11,10 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_weight_for_age <-
-  function(weight, age_in_days, sex, oedema, flag_threshold = c(-6, 5),
-             growthstandards = growthstandards_weianthro) {
-    anthro_zscore_adjusted("wei", weight, age_in_days, sex,
+  function(weight, age_in_days, age_in_months, sex, oedema,
+           flag_threshold = c(-6, 5),
+           growthstandards = growthstandards_weianthro) {
+    anthro_zscore_adjusted("wei", weight, age_in_days, age_in_months, sex,
       growthstandards, flag_threshold,
       allowed_age_range = c(0, 1856),
       !(oedema %in% "y")

--- a/R/z-score-weight-for-lenhei.R
+++ b/R/z-score-weight-for-lenhei.R
@@ -4,6 +4,7 @@
 #' @param length_measure numeric
 #' @param length_unit character
 #' @param age_in_days integer, the age in days.
+#' @param age_in_months numeric, the age in months.
 #' @param sex integer, the sex where 1 is male and 2 is female
 #' @param flag_threshold numeric, a length 1 threshold.
 #'        If the absolute value of the z-score is greater than
@@ -14,12 +15,13 @@
 #' @include z-score-helper.R
 #' @noRd
 anthro_zscore_weight_for_lenhei <-
-  function(weight, lenhei, lenhei_unit, age_in_days, sex, oedema,
-             flag_threshold = 5, growthstandards_wfl = growthstandards_wflanthro,
-             growthstandards_wfh = growthstandards_wfhanthro) {
+  function(weight, lenhei, lenhei_unit, age_in_days, age_in_months, sex, oedema,
+           flag_threshold = 5, growthstandards_wfl = growthstandards_wflanthro,
+           growthstandards_wfh = growthstandards_wfhanthro) {
     stopifnot(is.numeric(weight))
     stopifnot(is.numeric(weight))
     stopifnot(is.character(oedema) && all(oedema %in% c("y", "n")))
+    stopifnot(is.numeric(age_in_months))
     assert_valid_sex(sex)
     age_in_days <- assert_valid_age_in_days(age_in_days)
     assert_growthstandards(growthstandards_wfl)
@@ -118,7 +120,7 @@ anthro_zscore_weight_for_lenhei <-
 
     valid_zscore <- valid_zscore & !(oedema %in% "y")
     valid_zscore <- valid_zscore & (is.na(age_in_days) | (age_in_days <= 1856))
-    valid_zscore <- valid_zscore & age_under_60_month(age_in_days)
+    valid_zscore <- valid_zscore & age_in_months < 60
 
     flag_zscore(flag_threshold, "wfl", zscore, valid_zscore)
   }

--- a/R/z-score.R
+++ b/R/z-score.R
@@ -243,17 +243,59 @@ anthro_zscores <- function(sex,
     cbmi,
     cmeasure,
     csex,
-    anthro_zscore_length_for_age(clenhei, age_in_days, csex),
-    anthro_zscore_weight_for_age(weight, age_in_days, csex, oedema),
-    anthro_zscore_weight_for_lenhei(
-      weight, clenhei, cmeasure, age_in_days,
-      csex, oedema
+    anthro_zscore_length_for_age(
+      lenhei = clenhei,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex
     ),
-    anthro_zscore_bmi_for_age(cbmi, age_in_days, csex, oedema),
-    anthro_zscore_head_circumference_for_age(headc, age_in_days, csex),
-    anthro_zscore_arm_circumference_for_age(armc, age_in_days, csex),
-    anthro_zscore_triceps_skinfold_for_age(triskin, age_in_days, csex),
-    anthro_zscore_subscapular_skinfold_for_age(subskin, age_in_days, csex),
+    anthro_zscore_weight_for_age(
+      weight = weight,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex,
+      oedema = oedema
+    ),
+    anthro_zscore_weight_for_lenhei(
+      weight = weight,
+      lenhei = clenhei,
+      lenhei_unit = cmeasure,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex,
+      oedema = oedema
+    ),
+    anthro_zscore_bmi_for_age(
+      bmi = cbmi,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex,
+      oedema = oedema
+    ),
+    anthro_zscore_head_circumference_for_age(
+      headc,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex
+    ),
+    anthro_zscore_arm_circumference_for_age(
+      armc = armc,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex
+    ),
+    anthro_zscore_triceps_skinfold_for_age(
+      triskin = triskin,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex
+    ),
+    anthro_zscore_subscapular_skinfold_for_age(
+      subskin = subskin,
+      age_in_days = age_in_days,
+      age_in_months = age_in_months,
+      sex = csex
+    ),
     stringsAsFactors = FALSE
   )
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,3 @@
+to_months <- function(age_in_days) {
+  age_to_months(age_in_days, FALSE)
+}

--- a/tests/testthat/test-prevalence.R
+++ b/tests/testthat/test-prevalence.R
@@ -246,3 +246,16 @@ test_that("bug20190222: it does not crash if too few elements are in a group", {
     )
   )
 })
+
+test_that("Rounded values for age_in_days are used if age in months is provided", {
+  expect_silent(
+    res <- anthro_prevalence(
+      sex = c(1, 1, 1, 1, 1, 2),
+      age = c(59.9, 59.9, 59.92, 59.99, 59.992, 59.992),
+      is_age_in_month = TRUE,
+      weight = c(18, 15, 10, 15, 15, 15),
+      lenhei = c(100, 80, 100, 100, 100, 100)
+    )
+  )
+  expect_equal(res[1, 2], 5)
+})

--- a/tests/testthat/test-zscore-arm-circumference-for-age.R
+++ b/tests/testthat/test-zscore-arm-circumference-for-age.R
@@ -4,6 +4,7 @@ test_that("it returns NA if armc is <= 0", {
   observed <- anthro_zscore_arm_circumference_for_age(
     armc = c(-1, 0),
     age_in_days = c(100, 100),
+    age_in_months = to_months(c(100, 100)),
     sex = c(2, 2)
   )
   expect_true(all(is.na(observed$zac)))

--- a/tests/testthat/test-zscore-bmi-for-age.R
+++ b/tests/testthat/test-zscore-bmi-for-age.R
@@ -1,22 +1,37 @@
 context("zscores - bmi for age")
 describe("anthro_zscore_bmi_for_age", {
   it("fails if bmi is not numeric", {
-    expect_error(anthro_zscore_bmi_for_age("50", 44, 1, "n"), "measure")
+    expect_error(anthro_zscore_bmi_for_age(
+      "50", 44,
+      to_months(44), 1, "n"
+    ), "measure")
   })
   it("fails if age is not numeric", {
-    expect_error(anthro_zscore_bmi_for_age(50, "44", 1, "n"), "age")
+    expect_error(anthro_zscore_bmi_for_age(
+      50, "44",
+      to_months(44), 1, "n"
+    ), "age")
   })
   it("fails if sex is not 1 or 2", {
-    expect_error(anthro_zscore_bmi_for_age(50, 44, 3, "n"), "sex")
-    expect_error(anthro_zscore_bmi_for_age(50, 44, "F", "n"), "sex")
+    expect_error(anthro_zscore_bmi_for_age(
+      50, 44,
+      to_months(44), 3, "n"
+    ), "sex")
+    expect_error(anthro_zscore_bmi_for_age(
+      50, 44,
+      to_months(44), "F", "n"
+    ), "sex")
   })
   it("sets result to NA if oedema is y", {
-    expect_true(is.na(anthro_zscore_bmi_for_age(50, 44, 1, "y")$zbmi))
+    expect_true(is.na(anthro_zscore_bmi_for_age(
+      50, 44,
+      to_months(44), 1, "y"
+    )$zbmi))
   })
   it("has a default flag threshold of -6;5", {
-    observed <- anthro_zscore_bmi_for_age(25, 1, 2, "n")
+    observed <- anthro_zscore_bmi_for_age(25, 1, to_months(1), 2, "n")
     expect_equal(observed$fbmi, 1L)
-    observed <- anthro_zscore_bmi_for_age(10.37, 1, 2, "n",
+    observed <- anthro_zscore_bmi_for_age(10.37, 1, to_months(1), 2, "n",
       flag_threshold = c(-0.1, 0.1)
     )
     expect_equal(observed$fbmi, 1L)
@@ -25,6 +40,7 @@ describe("anthro_zscore_bmi_for_age", {
     observed <- anthro_zscore_bmi_for_age(
       c(50, 60),
       c(1, 1857),
+      to_months(c(1, 1857)),
       c(1, 1),
       c("n", "n")
     )
@@ -33,10 +49,10 @@ describe("anthro_zscore_bmi_for_age", {
     expect_equal(is.na(observed$fbmi), c(FALSE, TRUE))
   })
   it("ignores zscores for age < 0 and age >= 1856", {
-    observed <- anthro_zscore_bmi_for_age(50, 1857, 1, "n")
+    observed <- anthro_zscore_bmi_for_age(50, 1857, to_months(1857), 1, "n")
     expect_true(is.na(observed$zbmi))
     expect_true(is.na(observed$fbmi))
-    observed <- anthro_zscore_bmi_for_age(50, -1, 1, "n")
+    observed <- anthro_zscore_bmi_for_age(50, -1, to_months(1857), 1, "n")
     expect_true(is.na(observed$zbmi))
     expect_true(is.na(observed$fbmi))
   })
@@ -46,6 +62,7 @@ test_that("it returns NA if headc is <= 0", {
   observed <- anthro_zscore_bmi_for_age(
     bmi = c(-1, 0),
     age_in_days = c(100, 100),
+    age_in_months = to_months(c(100, 100)),
     sex = c(1, 1),
     oedema = c("n", "n")
   )

--- a/tests/testthat/test-zscore-head-circumference-for-age.R
+++ b/tests/testthat/test-zscore-head-circumference-for-age.R
@@ -4,6 +4,7 @@ test_that("it returns NA if headc is <= 0", {
   observed <- anthro_zscore_head_circumference_for_age(
     headc = c(-1, 0),
     age_in_days = c(100, 100),
+    age_in_months = to_months(c(100, 100)),
     sex = c(2, 2)
   )
   expect_true(all(is.na(observed$zhc)))

--- a/tests/testthat/test-zscore-length-for-age.R
+++ b/tests/testthat/test-zscore-length-for-age.R
@@ -1,44 +1,51 @@
 context("zscores - length for age")
 describe("anthro_zscore_length_for_age", {
   it("fails if lenhei is not numeric", {
-    expect_error(anthro_zscore_length_for_age("50", 44, 1))
+    expect_error(anthro_zscore_length_for_age("50", 44, to_months(44), 1))
   })
   it("fails if age is not numeric", {
-    expect_error(anthro_zscore_length_for_age(50, "44", 1))
+    expect_error(anthro_zscore_length_for_age(50, "44", to_months(44), 1))
   })
   it("fails if sex is not 1 or 2", {
-    expect_error(anthro_zscore_length_for_age(50, 44, 3))
-    expect_error(anthro_zscore_length_for_age(50, 44, "F"))
+    expect_error(anthro_zscore_length_for_age(50, 44, to_months(44), 3))
+    expect_error(anthro_zscore_length_for_age(50, 44, to_months(44), "F"))
   })
   it("computes the z-score for length for age", {
-    observed <- anthro_zscore_length_for_age(50, 44, 1)
+    observed <- anthro_zscore_length_for_age(50, 44, to_months(44), 1)
     expected <- round(((50 / 56.4833)^1 - 1) / (0.03492 * 1), digits = 2L)
     expect_true(is.data.frame(observed))
     expect_equal(observed$zlen, expected, tolerance = 1e-8)
     expect_equal(observed$flen, 0L)
   })
   it("has a default flag threshold of 6", {
-    observed <- anthro_zscore_length_for_age(50, 44, 1)
+    observed <- anthro_zscore_length_for_age(50, 44, to_months(44), 1)
     expect_equal(observed$flen, 0L)
-    observed <- anthro_zscore_length_for_age(50, 44, 1, flag_threshold = 2)
+    observed <- anthro_zscore_length_for_age(50, 44, to_months(44), 1,
+      flag_threshold = 2
+    )
     expect_equal(observed$flen, 1L)
   })
   it("does not compute zscores where no growthstandards are present", {
-    observed <- anthro_zscore_length_for_age(c(50, 60), c(1, 1857), c(1, 1))
+    observed <- anthro_zscore_length_for_age(
+      c(50, 60),
+      c(1, 1857),
+      to_months(c(1, 1857)),
+      c(1, 1)
+    )
     expect_true(is.data.frame(observed))
     expect_equal(is.na(observed$zlen), c(FALSE, TRUE))
     expect_equal(is.na(observed$flen), c(FALSE, TRUE))
   })
   it("ignores zscores for age < 0 and age >= 1856", {
-    observed <- anthro_zscore_length_for_age(50, 1857, 1)
+    observed <- anthro_zscore_length_for_age(50, 1857, to_months(1857), 1)
     expect_true(is.na(observed$zlen))
     expect_true(is.na(observed$flen))
-    observed <- anthro_zscore_length_for_age(50, -1, 1)
+    observed <- anthro_zscore_length_for_age(50, -1, to_months(1857), 1)
     expect_true(is.na(observed$zlen))
     expect_true(is.na(observed$flen))
   })
   it("returns NA if weight is <= 0", {
-    observed <- anthro_zscore_length_for_age(c(0, -1), 10, 1)
+    observed <- anthro_zscore_length_for_age(c(0, -1), 10, to_months(10), 1)
     expect_true(all(is.na(observed$zlen)))
     expect_true(all(is.na(observed$flen)))
     expect_true(is.numeric(observed$zlen))

--- a/tests/testthat/test-zscore-subscapular-skinfold-for-age.R
+++ b/tests/testthat/test-zscore-subscapular-skinfold-for-age.R
@@ -4,6 +4,7 @@ test_that("it returns NA if subskin is <= 0", {
   observed <- anthro_zscore_subscapular_skinfold_for_age(
     subskin = c(-1, 0),
     age_in_days = c(100, 100),
+    age_in_months = to_months(c(100, 100)),
     sex = c(2, 2)
   )
   expect_true(all(is.na(observed$zss)))

--- a/tests/testthat/test-zscore-weight-for-age.R
+++ b/tests/testthat/test-zscore-weight-for-age.R
@@ -1,29 +1,29 @@
 context("zscores - weight for age")
 describe("anthro_zscore_weight_for_age", {
   it("fails if weight is not numeric", {
-    expect_error(anthro_zscore_weight_for_age("50", 44, 1, "n"), "measure")
+    expect_error(anthro_zscore_weight_for_age("50", 44, to_months(44), 1, "n"), "measure")
   })
   it("fails if age is not numeric", {
-    expect_error(anthro_zscore_weight_for_age(50, "44", 1, "n"), "age")
+    expect_error(anthro_zscore_weight_for_age(50, "44", to_months(44), 1, "n"), "age")
   })
   it("fails if sex is not 1 or 2", {
-    expect_error(anthro_zscore_weight_for_age(50, 44, 3, "n"), "sex")
-    expect_error(anthro_zscore_weight_for_age(50, 44, "F", "n"), "sex")
+    expect_error(anthro_zscore_weight_for_age(50, 44, to_months(44), 3, "n"), "sex")
+    expect_error(anthro_zscore_weight_for_age(50, 44, to_months(44), "F", "n"), "sex")
   })
   it("sets result to NA if oedema is y", {
-    expect_true(is.na(anthro_zscore_weight_for_age(50, 44, 1, "y")$zwei))
+    expect_true(is.na(anthro_zscore_weight_for_age(50, 44, to_months(44), 1, "y")$zwei))
   })
   it("computes the z-score for length for age", {
-    observed <- anthro_zscore_weight_for_age(17, 1522, 2, "n")
+    observed <- anthro_zscore_weight_for_age(17, 1522, to_months(1522), 2, "n")
     expected <- 0.24
     expect_true(is.data.frame(observed))
     expect_equal(observed$zwei, expected, tolerance = 1e-8)
     expect_equal(observed$fwei, 0L)
   })
   it("has a default flag threshold of -6;5", {
-    observed <- anthro_zscore_weight_for_age(10.37, 1, 2, "n")
+    observed <- anthro_zscore_weight_for_age(10.37, 1, to_months(1), 2, "n")
     expect_equal(observed$fwei, 1L)
-    observed <- anthro_zscore_weight_for_age(17, 1522, 2, "n",
+    observed <- anthro_zscore_weight_for_age(17, 1522, to_months(1522), 2, "n",
       flag_threshold = c(-0.1, 0.1)
     )
     expect_equal(observed$fwei, 1L)
@@ -32,6 +32,7 @@ describe("anthro_zscore_weight_for_age", {
     observed <- anthro_zscore_weight_for_age(
       c(50, 60),
       c(1, 1857),
+      to_months(c(1, 1857)),
       c(1, 1),
       c("n", "n")
     )
@@ -40,16 +41,18 @@ describe("anthro_zscore_weight_for_age", {
     expect_equal(is.na(observed$fwei), c(FALSE, TRUE))
   })
   it("ignores zscores for age < 0 and age >= 1856", {
-    observed <- anthro_zscore_weight_for_age(50, 1857, 1, "n")
+    observed <- anthro_zscore_weight_for_age(50, 1857, to_months(1857), 1, "n")
     expect_true(is.na(observed$zwei))
     expect_true(is.na(observed$fwei))
-    observed <- anthro_zscore_weight_for_age(50, -1, 1, "n")
+    observed <- anthro_zscore_weight_for_age(50, -1, to_months(-1), 1, "n")
     expect_true(is.na(observed$zwei))
     expect_true(is.na(observed$fwei))
   })
   it("returns NA if weight is <= 0", {
     observed <- anthro_zscore_weight_for_age(
-      c(0, -1), c(10, 10),
+      c(0, -1),
+      c(10, 10),
+      to_months(c(10, 10)),
       c(1, 1), c("n", "n")
     )
     expect_true(all(is.na(observed$zwei)))

--- a/tests/testthat/test-zscore-weight-for-lenhei.R
+++ b/tests/testthat/test-zscore-weight-for-lenhei.R
@@ -6,6 +6,7 @@ test_that("it returns NA if weight is <= 0", {
     lenhei = 40,
     lenhei_unit = "l",
     age_in_days = 100,
+    age_in_months = to_months(100),
     sex = 2,
     oedema = "n"
   )
@@ -20,6 +21,7 @@ test_that("it returns NA if lenhei is <= 0", {
     lenhei = c(-1, 0),
     lenhei_unit = c("l", "l"),
     age_in_days = c(100, 100),
+    age_in_months = to_months(c(100, 100)),
     sex = c(2, 2),
     oedema = c("n", "n")
   )
@@ -33,7 +35,8 @@ test_that("it is only computed if age in month < 60", {
     weight = c(20, 20),
     lenhei = c(80, 80),
     lenhei_unit = c("l", "l"),
-    age_in_days = c(age_to_days(60, TRUE), age_to_days(60, TRUE) - 0.01),
+    age_in_days = c(age_to_days(60, TRUE), age_to_days(60 - 0.01, TRUE)),
+    age_in_months = c(60, 60 - 0.01),
     sex = c(2, 2),
     oedema = c("n", "n")
   )


### PR DESCRIPTION
Now rounds age in days and uses user supplied age where possible instead
of potentially double converions of age.